### PR TITLE
iPhoneのSafariで表示したときだけコードブロックのデザインが崩れる

### DIFF
--- a/assets/css/extended/override.css
+++ b/assets/css/extended/override.css
@@ -1,3 +1,8 @@
+body {
+  /* iPhone Safariのフォントサイズ自動調節でコードブロックが崩れないようにする */
+  -webkit-text-size-adjust: 100%;
+}
+
 /* 本文のline-heightを2にする */
 /* single.htmlの本文。デフォルト：1.6（bodyから継承） */
 .post-content {


### PR DESCRIPTION
iPhone Safariのフォントサイズ自動調節機能が原因のようで、`-webkit-text-size-adjust: 100%`を入れると直るらしい。まじかよ〜
https://ideal-reality.com/programing/highlightjs-line-numbers-js-css/